### PR TITLE
 Define build commands to work as expected, add build and bin folders to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 db.dat
+bin/
+build/
+

--- a/README.md
+++ b/README.md
@@ -1,10 +1,7 @@
 # ContactList
 
 ./envgen.sh
-
-cd build
-cmake ..
-make
+./build.sh
 
 The bin file will be generated at bin/ folder
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,4 @@
+cd build/ && cmake ..
+make install
+
+


### PR DESCRIPTION
The build comands doesn't work properly:
```
$ cd build cmake .. make
bash: cd: too many arguments
```
This PR uses build/ as build folder and bin/ as output folder.